### PR TITLE
docs: Improve YAML in code-blocks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,39 +30,33 @@ isHomePage: true | false
 
 Blank lines are important.
 
-```markdown
-<div class="code-group">
+    <div class="code-group">
 
-\`\`\`yaml
-# Your code here
-\`\`\`
+    ```yaml
+    # Your code here
+    ```
 
-</div>
-```
+    </div>
 
 To show line numbers:
 
-```markdown
-<div class="code-group" data-props='{ "lineNumbers": ["true"] }'>
+    <div class="code-group" data-props='{ "lineNumbers": ["true"] }'>
 
-\`\`\`yaml
-# Your code here
-\`\`\`
+    ```yaml
+    # Your code here
+    ```
 
-</div>
-```
+    </div>
 
 To add a file name:
 
-```
-<div class="code-group" data-props='{ "lineNumbers": ["true"], "labels": ["my-file.yaml"] }'>
+    <div class="code-group" data-props='{ "lineNumbers": ["true"], "labels": ["my-file.yaml"] }'>
 
-\`\`\`yaml
-# Your code here
-\`\`\`
+    ```yaml
+    # Your code here
+    ```
 
-</div>
-```
+    </div>
 
 **Info/Warning/Danger**
 


### PR DESCRIPTION
The escaped backticks were used to nest them originally, but this makes the docs hard to read.

I've removed used of markdown highlighting and used the 4-space indentation to turn the snippets into code-blocks - this means the backticks are rendered as plain text.