### PR TITLE
Fix a few mistakes in the setup instructions

### DIFF
--- a/docs/authentication/gitlab.md
+++ b/docs/authentication/gitlab.md
@@ -11,7 +11,7 @@ From your Gitlab **admin area**, [add a new application](https://docs.gitlab.com
 | Name   | Meli | 
 | Redirect URL | `<meli-server-url>/auth/gitlab/callback` |
 | Trusted / Confidential | true |
-| Scopes | api |
+| Scopes | read_api |
 
 After creating the application, Gitlab will give you both the **Client ID** and **Client Secret**, which they respectively name **Application ID** and **Application Secret**.
 
@@ -33,7 +33,7 @@ services:
       # ...
       MELI_GITLAB_CLIENT_ID: <your-gitlab-application-id>
       MELI_GITLAB_CLIENT_SECRET: <your-gitlab-application-secret>
-      MELI_GITLAB_URL: http://10.0.1.23:3003
+      MELI_GITLAB_URL: https://gitlab.com # Or the URL to your own Gitlab instance
       # restrict access to your Gitlab group
       MELI_GITLAB_GROUPS: my-org-1,my-org-2
 ```


### PR DESCRIPTION
The scope requested for Gitlab is not `api`, but rather should be `read_api` (as can be seen [here](https://github.com/getmeli/meli/blob/b045ce50d944320d515b3193340786f0fc8f129c/server/src/auth/passport/gitlab.ts#L32)).  Also, the value for `MELI_GITLAB_URL` should be the URL to the Gitlab instance to be authenticated against.  Unless you are running your own Gitlab instance, that would be `http://gitlab.com`.  The previous value in this document was probably a private Gitlab instance running on port 3003 used for testing or something.  But it wasn't a useful value for anybody reading the documentation.  This document assumes `gitlab.com` but points out how to handle the case of a private instance.

This closes getmeli/meli#243.